### PR TITLE
Add TTS routing for selected chat channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,12 @@ Currently supported languages:
 - nederlands (nederlands.bat)
 - turkce (turkce.bat)
 ## You must go to your Documents/AAClassic/Addon/cant_read folder and launch your target language's batch file. This window must stay open while you are playing for translations to come through.
+
+### Text-to-Speech Playback
+To hear chat messages spoken aloud, run `tts.bat` with an optional voice name:
+
+```
+tts.bat Ash
+```
+
+Only local, whisper, party, nation, family and faction chats are sent to the TTS server.

--- a/main.lua
+++ b/main.lua
@@ -31,6 +31,16 @@ local function itemIdFromItemLinkText(itemLinkText)
 end 
 
 local function writeChatToTranslatingFile(channel, unit, isHostile, name, message, speakerInChatBound, specifyName, factionName, trialPosition)
+    -- Only handle chat from whisper, local, party, nation, family and faction
+    local allowedChannels = {
+        ["-3"] = true, -- whisper
+        ["0"]  = true, -- local
+        ["4"]  = true, -- party
+        ["6"]  = true, -- nation
+        ["9"]  = true, -- family
+        ["14"] = true  -- faction
+    }
+    if not allowedChannels[tostring(channel)] then return end
     if name ~= nil and #message > 2 then
         -- Skip messages beginning with x and a space (looking for raid invites)
         if string.sub(message, 1, 1) == "x" and string.sub(message, 2, 2) == " " then return end  

--- a/scripts/tts_play.ps1
+++ b/scripts/tts_play.ps1
@@ -1,0 +1,41 @@
+param(
+    [string]$voice = "Ash"
+)
+
+$baseUrl = "http://100.97.17.9:8080"
+$pathFile = '.\to_be_translated.lua'
+
+function Invoke-TTS {
+    param(
+        [string]$text
+    )
+    $fields = $text -split "\|\|\|\|"
+    if ($fields.Length -lt 4) { return }
+    $channel = $fields[1]
+    $name = $fields[2]
+    $message = $fields[3]
+    $allowed = @("-3","0","4","6","9","14")
+    if ($allowed -notcontains $channel) { return }
+    $payload = @{ text = $message; voice = $voice } | ConvertTo-Json
+    try {
+        $resp = Invoke-WebRequest -Uri "$baseUrl/tts_clone" -Method Post -Body $payload -ContentType "application/json"
+        $tmp = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.wav')
+        [System.IO.File]::WriteAllBytes($tmp, $resp.Content)
+        $player = New-Object System.Media.SoundPlayer $tmp
+        $player.PlaySync()
+        Remove-Item $tmp -ErrorAction SilentlyContinue
+    } catch {
+        Write-Host "TTS request failed: $_" -ForegroundColor Red
+    }
+}
+
+if (Test-Path $pathFile) {
+    Get-Content -Path $pathFile -Wait -Tail 0 -Encoding UTF8 | ForEach-Object {
+        if ($_ -ne "" -and $_ -ne "{" -and $_ -ne "}") {
+            Invoke-TTS -text (Get-Content -Path $pathFile -Encoding UTF8)[1]
+        }
+    }
+} else {
+    Write-Host "Chat log file not found: $pathFile"
+    exit 1
+}

--- a/tts.bat
+++ b/tts.bat
@@ -1,0 +1,14 @@
+@echo off
+set VOICE=%1
+if "%VOICE%"=="" set VOICE=Ash
+
+:START
+echo Cant Read TTS playback is now running.
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "scripts/tts_play.ps1" -voice "%VOICE%"
+if %ERRORLEVEL% NEQ 0 (
+    echo An error has been encountered, attempting to restart...
+    timeout /t 1 > nul
+    goto START
+)
+echo Cant Read TTS playback is now closed.
+pause


### PR DESCRIPTION
## Summary
- Send local, whisper, party, nation, family and faction messages to a text-to-speech endpoint
- Provide PowerShell helper that streams chat text to TTS and plays audio
- Document TTS usage and add batch file runner

## Testing
- ⚠️ `pwsh -NoLogo -File scripts/tts_play.ps1 -voice Test` *(command failed: pwsh not found)*
- ⚠️ `powershell -NoLogo -File scripts/tts_play.ps1 -voice Test` *(command failed: powershell not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38517121c832eb23045c96eb9b451