### PR TITLE
Log chat and send startup TTS message

### DIFF
--- a/scripts/tts_play.ps1
+++ b/scripts/tts_play.ps1
@@ -4,6 +4,24 @@ param(
 
 $baseUrl = "http://100.97.17.9:8080"
 $pathFile = '.\to_be_translated.lua'
+$logPath = '.\log.txt'
+
+function Send-TTS {
+    param(
+        [string]$textToSpeak
+    )
+    $payload = @{ text = $textToSpeak; voice = $voice } | ConvertTo-Json
+    try {
+        $resp = Invoke-WebRequest -Uri "$baseUrl/tts_clone" -Method Post -Body $payload -ContentType "application/json"
+        $tmp = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.wav')
+        [System.IO.File]::WriteAllBytes($tmp, $resp.Content)
+        $player = New-Object System.Media.SoundPlayer $tmp
+        $player.PlaySync()
+        Remove-Item $tmp -ErrorAction SilentlyContinue
+    } catch {
+        Write-Host "TTS request failed: $_" -ForegroundColor Red
+    }
+}
 
 function Invoke-TTS {
     param(
@@ -16,18 +34,19 @@ function Invoke-TTS {
     $message = $fields[3]
     $allowed = @("-3","0","4","6","9","14")
     if ($allowed -notcontains $channel) { return }
-    $payload = @{ text = $message; voice = $voice } | ConvertTo-Json
-    try {
-        $resp = Invoke-WebRequest -Uri "$baseUrl/tts_clone" -Method Post -Body $payload -ContentType "application/json"
-        $tmp = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), '.wav')
-        [System.IO.File]::WriteAllBytes($tmp, $resp.Content)
-        $player = New-Object System.Media.SoundPlayer $tmp
-        $player.PlaySync()
-        Remove-Item $tmp -ErrorAction SilentlyContinue
-    } catch {
-        Write-Host "TTS request failed: $_" -ForegroundColor Red
-    }
+
+    $logLine = "$(Get-Date -Format 'u') [$name]: $message"
+    Add-Content -Path $logPath -Value $logLine
+    Write-Host $logLine
+
+    Send-TTS -textToSpeak $message
 }
+
+# Play startup message to confirm audio
+$startupMessage = "Voice audio working"
+Add-Content -Path $logPath -Value "$(Get-Date -Format 'u') [System]: $startupMessage"
+Write-Host "$(Get-Date -Format 'u') [System]: $startupMessage"
+Send-TTS -textToSpeak $startupMessage
 
 if (Test-Path $pathFile) {
     Get-Content -Path $pathFile -Wait -Tail 0 -Encoding UTF8 | ForEach-Object {

--- a/tts.bat
+++ b/tts.bat
@@ -4,6 +4,7 @@ if "%VOICE%"=="" set VOICE=Ash
 
 :START
 echo Cant Read TTS playback is now running.
+echo Chat log will be saved to log.txt.
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "scripts/tts_play.ps1" -voice "%VOICE%"
 if %ERRORLEVEL% NEQ 0 (
     echo An error has been encountered, attempting to restart...


### PR DESCRIPTION
## Summary
- Log each spoken chat message to `log.txt` and display it in the console
- Add startup voice check that sends "Voice audio working" to the TTS endpoint
- Inform users that chat logs are saved when running `tts.bat`

## Testing
- `powershell -NoProfile -Command "Write-Host 'test'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38a9d22ec832e9b17a05e0b084c32